### PR TITLE
fix: use replace instead

### DIFF
--- a/encrypt.py
+++ b/encrypt.py
@@ -51,8 +51,7 @@ class client:
         with open(tmpfile,"w",encoding="utf-8") as outfile:
             json.dump(self.dict,outfile)
         outfile.close()
-        os.remove(self.outputFile)
-        os.rename(tmpfile,self.outputFile)
+        os.replace(tmpfile,self.outputFile)
         print("----- finished sync disk -----")
 
     def syncToConfigFile(self):


### PR DESCRIPTION
use atomic `os.replace` api